### PR TITLE
fixed required validation for textarea

### DIFF
--- a/addon/mixins/validatable-input.js
+++ b/addon/mixins/validatable-input.js
@@ -109,6 +109,7 @@ export default Ember.Mixin.create({
       return;
     }
 
+    // Validate Textarea with proper text and not accept only blank spaces, only new line characters.
     if(input.tagName.toLowerCase() === 'textarea') {
       var content = Ember.$.trim(Ember.$(input).val());
       if(content.length === 0) {


### PR DESCRIPTION
Hi @bakura10,

When we apply <code>required</code> validation for textarea, it also accept blank spaces, new line characters, carriage return etc. which is invalid.
Even same thing happens with text-inputs. Its not issue with this addon but the html5 accepts blank spaces as valid.

So to fix this, I have added few changes to validate <i>Textarea and text-inputs</i> by accepting proper values and no blank spaces or new-line characters.

Can you please have a look here? Also let me know your inputs and suggestions to solve this issue.
(or it might not be the issue but I would like if you can help me here to get better validation).

Thanks :smile:
