### PR TITLE
Fix Ember-Data error extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ the validatable form:
 ```html
 {{#validatable-form action='save' model=model}}
   <div class="form-control">
-    {{input name='first-name' value=firstName required='required'}}
+    {{input id='first-name' value=firstName required='required'}}
   </div>
 
   <div class="form-control">
-    {{input name='last-name' value=lastName required='required'}}
+    {{input id='last-name' value=lastName required='required'}}
   </div>
 
   <input type="submit"}}
@@ -139,6 +139,22 @@ This will provide two things:
 When client validation successfully passes, the action is submitted. In case of errors that are returned by server,
 Ember CLI HTML5 Validation will automatically extracts errors (assuming that errors hash is formatted properly) and
 will show them along corresponding fields.
+
+For this to work, you must configure Ember-Data to properly creates a DS.InvalidError object on failure (this is done
+out of the box if you are using ActiveModel Adapter). Furthermore, you must add an "id" on each input, that is the
+dasherized version of the property. For instance, if your server returns the following payload:
+
+```json
+{
+  "errors": {
+    "first_name": [
+      "Your First Name is not valid (lol)"
+    ]
+  }
+}
+```
+
+Your input must have an id whose value is "first-name".
 
 > This is currently a bit hacky and I want to make this more efficient / allow to work on associations.
 

--- a/addon/components/validatable-form.js
+++ b/addon/components/validatable-form.js
@@ -67,25 +67,22 @@ export default Ember.Component.extend({
    * @returns {void}
    */
   extractServerErrors: function() {
-    var errors = this.get('model.errors'),
-        childViews = this.get('childViews');
+    var errors = this.get('model.errors');
 
-    // This thing can be pretty inefficient if you have lot of form elements... we need to find
-    // a better way!
+    // For now, we assume that there are "id" properly set and that they match the attribute name
     errors.forEach(function(item) {
       var attribute = Ember.String.dasherize(item.attribute),
-        childViewLength = childViews.get('length');
+          element = Ember.$.find('#' + attribute);
 
-      for (var i = 0 ; i !== childViewLength ; ++i) {
-        if (attribute === childViews[i].get('elementId')) {
-          childViews[i].setCustomErrorMessage(item.message);
-          break;
-        }
+      if (element.length > 0) {
+        element[0].setCustomValidity(item.message);
       }
     });
 
+    // Force validation of the form
+    this.get('element').checkValidity();
     this.scrollToFirstError();
-  }.observes('model.errors.length'),
+  }.observes('model.errors.[]'),
 
   /**
    * Scroll to the first input field that does not pass the validation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-html5-validation",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
Hi,

This PR includes fix that simplify and unify how error message are extracted when using Ember-Data. I've also slightly updated the doc. This also removes the "setCustomError" message on validatable input, as I now take advantage of the "setCustomValidity" to set server errors as custom message, adn take advantage of the native invalid event.

It also removes useless listeners on input.

@swatijadhav as I don't have tests yet I'm not sure this does not cause any regression. I'm tagging as 0.0.11, could you please try it ?
