### PR TITLE
isLoading being set to true disables the async-button

### DIFF
--- a/addon/components/async-button.js
+++ b/addon/components/async-button.js
@@ -69,9 +69,7 @@ export default Ember.Component.extend({
   observesLoading: function() {
     if (this.get('isLoading')) {
       this.set('isDefault', false);
-    }
-
-    if (!this.get('isLoading')) {
+    } else {
       Ember.run.later(this, function() {
         this.set('isDefault', true);
       }, 1500);

--- a/addon/components/async-button.js
+++ b/addon/components/async-button.js
@@ -62,13 +62,16 @@ export default Ember.Component.extend({
   }.property('isDefault', 'isValid').readOnly(),
 
   /**
+   * Set isDefault to false when isLoading is triggered to disable the button.
    * When the isLoading goes back to "false", we check if the button is in an error state. If that's
    * the case, we enforce the error state, otherwise we switch to "valid"
    */
   observesLoading: function() {
-    if (!this.get('isLoading')) {
+    if (this.get('isLoading')) {
       this.set('isDefault', false);
+    }
 
+    if (!this.get('isLoading')) {
       Ember.run.later(this, function() {
         this.set('isDefault', true);
       }, 1500);


### PR DESCRIPTION
Followup to #18.

Went for a minimal approach. Though considered changing disabled to be triggered by a new attribute like "isDisabled" or to set it directly as this seems like it may go beyond the original intention of "isDefault".

Thoughts?