### PR TITLE
Fixed issue with acceptance tests failing due to 'set' being calling on a destroyed async-button

### DIFF
--- a/addon/components/async-button.js
+++ b/addon/components/async-button.js
@@ -69,9 +69,7 @@ export default Ember.Component.extend({
   observesLoading: function() {
     if (this.get('isLoading')) {
       this.set('isDefault', false);
-    }
-
-    if (!this.get('isLoading')) {
+    } else {
       Ember.run.later(this, function() {
         this.set('isDefault', true);
       }, 1500);

--- a/addon/components/async-button.js
+++ b/addon/components/async-button.js
@@ -71,7 +71,13 @@ export default Ember.Component.extend({
       this.set('isDefault', false);
     } else {
       Ember.run.later(this, function() {
-        this.set('isDefault', true);
+        /**
+         * Check to make sure set is not called after the component is already destroyed.
+         * This generates an error that causes acceptance tests to fail and is unnecessary.
+        */
+        if (!this.get('isDestroyed')) {
+          this.set('isDefault', true);
+        }
       }, 1500);
     }
   }.observes('isLoading')


### PR DESCRIPTION
I was running into the attached error with QUnit acceptance tests that clicked on a async-button and then transitioned to another route. Wrote this patch to fix it. Let me know if you need more information on how to reproduce it.
<img width="1047" alt="screen shot 2015-08-10 at 5 23 27 pm" src="https://cloud.githubusercontent.com/assets/8106/9187375/90fd5dbe-3f84-11e5-882e-419d935b036c.png">
