### PR TITLE
Only reopen Ember.Select if it exists

### DIFF
--- a/addon/ext/select.js
+++ b/addon/ext/select.js
@@ -5,4 +5,7 @@ import ValidatableInput from '../mixins/validatable-input';
  * @namespace Ember
  * @class Select
  */
-Ember.Select.reopen(ValidatableInput);
+// Ember.Select is removed in v2.0
+if (!!Ember.Select){
+  Ember.Select.reopen(ValidatableInput);
+}


### PR DESCRIPTION
Ember.Select is [deprecated in Ember v1.13 and removed in v2](http://emberjs.com/deprecations/v1.x/#toc_ember-select)

This patch handles both cases so it doesn't blow up on v2