### PR TITLE
Verify form-validity manually because checkValidity() returns always true in samsung android 4.4.2 version

### DIFF
--- a/addon/components/validatable-form.js
+++ b/addon/components/validatable-form.js
@@ -32,8 +32,19 @@ export default Ember.Component.extend({
    */
   submit: function() {
     var form = this.get('element');
+    var allValidElements = true;
 
-    if (form.checkValidity()) {
+    if(form.checkValidity()) {
+      $('form input, form select, form textarea').each(function(){
+        allValidElements = this.validity.valid;
+        if(!allValidElements) {
+          Ember.$(this).trigger("invalid"); // to highlight invalid field.
+          return false;
+        }
+      });
+    }
+
+    if (form.checkValidity() && allValidElements) {
       this.sendAction('action', this.get('model'));
     } else {
       this.scrollToFirstError();


### PR DESCRIPTION
Hi @bakura10 

While testing our application, in Samsung Device having Android 4.4.2 version, we found issue that forms were getting submitted even though it has invalid data.
After debugging it, we found that `checkValidity()` always returns `true` even though it has invalid data.

Some other people also faced similar issue: https://groups.google.com/forum/#!topic/phonegap/x9h7kgd_tkw

Here I have added few changes, to get it work in Samsung Device having Android 4.4.2 version.

Can you please verify it? also let me know if you have any suggestions and better ideas.

Thanks :smile:  
